### PR TITLE
Add auth loading state to remove jitters in initial load. 

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,6 +23,9 @@ function App() {
   const [filteredCafes, setFilteredCafes] = useState([]);
   const cafesCollectionRef = collection(db, "cafes"); // Firebase collection ref
 
+  const [isAuthLoading, setIsAuthLoading] = useState(true); // Add loading state for auth
+
+
   const getCafeList = async () => {
     try {
       const data = await getDocs(cafesCollectionRef);
@@ -42,6 +45,7 @@ function App() {
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
       setUser(currentUser);
+      setIsAuthLoading(false); // Set loading to false once we have the auth state
     });
     return unsubscribe; // Cleanup subscription
   }, []);
@@ -70,6 +74,17 @@ function App() {
       console.error(err);
     }
   };
+
+  if (isAuthLoading) {
+    return (
+      <div className="h-screen flex items-center justify-center">
+        <div className="flex flex-col items-center gap-4">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-[#6B7AEE]"></div>
+          <p className="text-gray-500">Loading...</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div>


### PR DESCRIPTION
Without the state; 
https://github.com/user-attachments/assets/a797675d-6f9c-45f0-bc0d-8c2e4e9f1588

With the state: 

https://github.com/user-attachments/assets/d87a2ae8-25ae-4218-b270-4588e0de14b6



This also fixed the scenario where if the user refreshes the page in the profile page it would go, Auth -> Profile -> and back to home. And you would have to navigate to profile again. This PR fixes this recurring problem, however, ideally we should have a dedicated auth state management which will take care of this, maybe an react router outlet or something similar to them. 


